### PR TITLE
Fix of the compare function

### DIFF
--- a/test/modifiedMethods.js
+++ b/test/modifiedMethods.js
@@ -421,7 +421,7 @@ describe('Modified Array Methods',()=>{
 		})
 		describe('sort',()=>{
 			function sort(a,b){
-				return a.name>b.name;
+				return a.name>b.name ? 1 : (a.name === b.name ? 0 : -1);
 			}
 			it('sort the array if given a function',()=>{
 				var wrapped = wrap([{name:'b'},{name:'d'},{name:'a'},{name:'c'}],'name');


### PR DESCRIPTION
The previous version of the compare function was not consistent (it did not follow the requirements on the compare function), see https://tc39.github.io/ecma262/#sec-array.prototype.sort for details. The given test-case is too small to notice that on V8 (the default JavaScript engine of Node.js) but the test fails on an alternative JavaScript engine that I tried. You can see that the compare function is not correct by using it to sort larger arrays. For example, if you sort the letters of a well known sentence:
`"the quick brown fox jumps over the lazy dog".split('').sort((a,b) => a<b).join('')`
returns `"utyztuvxwogroknolohqjhmpsrifbdeecea        "` on Node.js 6.7.0. While `"the quick brown fox jumps over the lazy dog".split('').sort((a,b) => a<b ? 1 : (a===b ? 0 : -1)).join('')` returns the correct result `'zyxwvuuttsrrqpoooonmlkjihhgfeeedcba        '`.